### PR TITLE
Update the name of the cx-freeze depencency

### DIFF
--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -15,7 +15,7 @@ RUN pacman -Sy --noconfirm mingw-w64-x86_64-gtk3 mingw-w64-x86_64-python-gobject
  mingw-w64-x86_64-python-lxml mingw-w64-x86_64-qpdf mingw-w64-x86_64-pybind11 \
  mingw-w64-x86_64-gettext mingw-w64-x86_64-gnutls mingw-w64-x86_64-python-pip \
  mingw-w64-x86_64-python-pillow mingw-w64-x86_64-libhandy \
- mingw-w64-x86_64-python-cx_Freeze
+ mingw-w64-x86_64-python-cx-freeze
 RUN wine /mingw64/bin/gdk-pixbuf-query-loaders.exe --update-cache \
  && wineserver --wait
 RUN wine reg add "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Environment" /f /v PATH /t REG_SZ /d "z:\\mingw64\\bin;c:\\windows\\system32" \


### PR DESCRIPTION
The additional provides was recently removed in the alpine package, therefore cx_Freeze could no longer be found