### PR TITLE
Win32 overhaul

### DIFF
--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -15,7 +15,8 @@ RUN pacman -Sy --noconfirm mingw-w64-x86_64-gtk3 mingw-w64-x86_64-python-gobject
  mingw-w64-x86_64-python-lxml mingw-w64-x86_64-qpdf mingw-w64-x86_64-pybind11 \
  mingw-w64-x86_64-gettext mingw-w64-x86_64-gnutls mingw-w64-x86_64-python-pip \
  mingw-w64-x86_64-python-pillow mingw-w64-x86_64-libhandy \
- mingw-w64-x86_64-python-cx-freeze
+ mingw-w64-x86_64-python-cx-freeze \
+ mingw-w64-x86_64-python-dateutil
 RUN wine /mingw64/bin/gdk-pixbuf-query-loaders.exe --update-cache \
  && wineserver --wait
 RUN wine reg add "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Environment" /f /v PATH /t REG_SZ /d "z:\\mingw64\\bin;c:\\windows\\system32" \
@@ -25,5 +26,5 @@ RUN cd /mingw64/share/glib-2.0/schemas \
  && wineserver --wait
 ENV WINEDEBUG=-all
 RUN wine \
- python3.exe -m pip install pikepdf==9.4.2 img2pdf==0.5.1 python-dateutil keyboard darkdetect \
+ python3.exe -m pip install pikepdf==9.4.2 img2pdf==0.5.1 keyboard darkdetect \
  && wineserver --wait

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -10,11 +10,20 @@ RUN mkdir -p /etc/pacman.d \
  && pacman-key --populate msys2
 # alexpux@gmail.com signature is not accepted
 RUN echo -e "5\ny\n" | GNUPGHOME=/etc/pacman.d/gnupg gpg --no-tty --command-fd 0 --expert --edit-key AD351C50AE085775EB59333B5F92EFC1A47D45A1 trust
-RUN pacman -Sy --noconfirm mingw-w64-x86_64-gtk3 mingw-w64-x86_64-python-gobject \
- mingw-w64-x86_64-python-cairo mingw-w64-x86_64-poppler mingw-w64-x86_64-gcc \
- mingw-w64-x86_64-python-lxml mingw-w64-x86_64-qpdf mingw-w64-x86_64-pybind11 \
- mingw-w64-x86_64-gettext mingw-w64-x86_64-gnutls mingw-w64-x86_64-python-pip \
- mingw-w64-x86_64-python-pillow mingw-w64-x86_64-libhandy \
+RUN pacman -Sy --noconfirm \
+ mingw-w64-x86_64-gtk3 \
+ mingw-w64-x86_64-python-gobject \
+ mingw-w64-x86_64-python-cairo \
+ mingw-w64-x86_64-poppler \
+ mingw-w64-x86_64-gcc \
+ mingw-w64-x86_64-python-lxml \
+ mingw-w64-x86_64-qpdf \
+ mingw-w64-x86_64-pybind11 \
+ mingw-w64-x86_64-gettext \
+ mingw-w64-x86_64-gnutls \
+ mingw-w64-x86_64-python-pip \
+ mingw-w64-x86_64-python-pillow \
+ mingw-w64-x86_64-libhandy \
  mingw-w64-x86_64-python-cx-freeze \
  mingw-w64-x86_64-python-dateutil
 RUN wine /mingw64/bin/gdk-pixbuf-query-loaders.exe --update-cache \

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -15,7 +15,7 @@ RUN pacman -Sy --noconfirm mingw-w64-x86_64-gtk3 mingw-w64-x86_64-python-gobject
  mingw-w64-x86_64-python-lxml mingw-w64-x86_64-qpdf mingw-w64-x86_64-pybind11 \
  mingw-w64-x86_64-gettext mingw-w64-x86_64-gnutls mingw-w64-x86_64-python-pip \
  mingw-w64-x86_64-python-pillow mingw-w64-x86_64-libhandy \
- mingw-w64-x86_64-python-cx_Freeze
+ mingw-w64-x86_64-python-cx-freeze
 RUN wine /mingw64/bin/gdk-pixbuf-query-loaders.exe --update-cache \
  && wineserver --wait
 RUN wine reg add "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Environment" /f /v PATH /t REG_SZ /d "z:\\mingw64\\bin;c:\\windows\\system32" \

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.0
+FROM alpine:3.22
 RUN apk add pacman-makepkg curl libgcc py3-distutils-extra py3-setuptools intltool wine
 RUN mkdir -p /etc/pacman.d \
  && curl https://raw.githubusercontent.com/msys2/MSYS2-packages/master/pacman-mirrors/mirrorlist.mingw | sed 's|$repo|x86_64|g' > /etc/pacman.d/mirrorlist.mingw64 \

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -17,10 +17,11 @@ RUN pacman -Sy --noconfirm \
  mingw-w64-x86_64-poppler \
  mingw-w64-x86_64-gcc \
  mingw-w64-x86_64-python-lxml \
- mingw-w64-x86_64-qpdf \
+ mingw-w64-x86_64-python-pikepdf \
  mingw-w64-x86_64-pybind11 \
  mingw-w64-x86_64-gettext \
  mingw-w64-x86_64-gnutls \
+ mingw-w64-x86_64-img2pdf \
  mingw-w64-x86_64-python-pip \
  mingw-w64-x86_64-python-pillow \
  mingw-w64-x86_64-libhandy \
@@ -35,5 +36,5 @@ RUN cd /mingw64/share/glib-2.0/schemas \
  && wineserver --wait
 ENV WINEDEBUG=-all
 RUN wine \
- python3.exe -m pip install pikepdf==9.4.2 img2pdf==0.5.1 keyboard darkdetect \
+ python3.exe -m pip install keyboard darkdetect \
  && wineserver --wait

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -15,15 +15,11 @@ RUN pacman -Sy --noconfirm \
  mingw-w64-x86_64-python-gobject \
  mingw-w64-x86_64-python-cairo \
  mingw-w64-x86_64-poppler \
- mingw-w64-x86_64-gcc \
- mingw-w64-x86_64-python-lxml \
  mingw-w64-x86_64-python-pikepdf \
- mingw-w64-x86_64-pybind11 \
  mingw-w64-x86_64-gettext \
  mingw-w64-x86_64-gnutls \
  mingw-w64-x86_64-img2pdf \
  mingw-w64-x86_64-python-pip \
- mingw-w64-x86_64-python-pillow \
  mingw-w64-x86_64-libhandy \
  mingw-w64-x86_64-python-cx-freeze \
  mingw-w64-x86_64-python-dateutil


### PR DESCRIPTION
This includes #6 

I updated the base image and installed some dependencies directly from msys2 which have recently been packaged. Removed other build dependencies for those, as they are no longer explicitly needed.

The image builds fine but I have NOT tried to build a pdfarranger with it yet.