### PR TITLE
Sourcebuild: add python3-pytest

### DIFF
--- a/sourcebuild/Dockerfile
+++ b/sourcebuild/Dockerfile
@@ -6,4 +6,5 @@ RUN apt-get update && apt-get -y install python3-pip python3-distutils-extra pyt
  appstream desktop-file-utils gsettings-desktop-schemas curl bash python3-lxml \
  pybind11-dev python3-dev cmake libhandy-1-0 libglib2.0-bin libgnutls28-dev \
  fonts-cantarell git python3-virtualenv zlib1g libjpeg-turbo8-dev libssl-dev \
- python3-venv gettext python3-dogtail python3-dateutil img2pdf python3-pyatspi
+ python3-venv gettext python3-dogtail python3-dateutil img2pdf python3-pyatspi \
+ python3-pytest


### PR DESCRIPTION
This was used to build ghcr.io/pdfarranger/pdfarranger-pikepdf-qpdf-dev-docker-ci:1.1.0